### PR TITLE
Fixes Issues with Roland S-7xx Showing as Empty, Throwing Errors, and Producing Invalid Directory Names

### DIFF
--- a/smpl_extract/roland/s7xx/image.py
+++ b/smpl_extract/roland/s7xx/image.py
@@ -170,8 +170,9 @@ RolandS7xxImageStruct = Struct(
     "fat" / Computed(lambda this: this.fat_area.fat),
     "_dir_version" / Computed(lambda this: this.fat_area.version),
     "volumes" / VolumeEntriesList(
-        lambda this: this.id_area.num_volumes
-    )
+        lambda this: this.id_area.num_volumes,
+        lambda this: this.id_area.num_performances
+    )  # type: ignore
 )
 @dataclass
 class RolandS7xxImageContainer:

--- a/smpl_extract/roland/s7xx/image.py
+++ b/smpl_extract/roland/s7xx/image.py
@@ -96,7 +96,7 @@ class IdAreaAdapter(Adapter):
 
     _S7XX_REGEX = re.compile(r"\s*S7\d\d\s+MR25A", flags=re.I)
     _VERSION_REGEX = re.compile(
-        r"\s*(S-\d+)\s+(\w+)\s+Disk\s+Ver\.?\s*(\d(\.\d+)?\w*)\s*",
+        r"\s*([Ss][A-z]*-\d+)\s+([A-z\s\-]*?Disk)\s?([A-z\s]*?)\s+Ver\.?\s*(\d(\.\d+)?[\w-]*)\s*",
         flags=re.I
     )
     _COPYRIGHT_REGEX = re.compile(r"\s*Copyright\s+Roland", flags=re.I)
@@ -123,7 +123,7 @@ class IdAreaAdapter(Adapter):
 
         model_version = match_results[1].groups()[0]
         disk_type = match_results[1].groups()[1]
-        disk_version = match_results[1].groups()[2]
+        disk_version = match_results[1].groups()[3]
 
         result = IdArea(
             revision=container.revision,

--- a/smpl_extract/structural.py
+++ b/smpl_extract/structural.py
@@ -308,10 +308,12 @@ class Image(Traversable):
             export_name = match.group(1)
         if len(export_name) <= 0:
             export_name = "0"
-        if is_file:
-            match = re.match(r"\w", export_name)
-            if not match:
-                export_name = "0" + export_name
+        match = re.match(r"\w", export_name)
+        if not match:
+            export_name = "0" + export_name
+        if not is_file:
+            if export_name[-1] in (".", "-"):
+                export_name = export_name + "0"
         return export_name
 
 

--- a/smpl_extract/util/constructs.py
+++ b/smpl_extract/util/constructs.py
@@ -145,8 +145,9 @@ class ElementAdapter(Adapter):
         self.name_key = name_key
 
 
+    @classmethod
     def wrap_child_realization(
-        self,
+        cls,
         f_realize: Callable[[], List[Element]],
         context: Dict[str, Any]
     ) -> Callable[[Dict[str, Any]], List[Element]]:
@@ -356,7 +357,7 @@ class SafeListConstruct(Array):
 
     def _parse(self, stream, context, path):
         count = evaluate(self.count, context)
-        if count <= 0:
+        if count < 0:
             raise RangeError(f"invalid count {count}", path=path)
         obj = dict()
         if self.predicate is not None:

--- a/smpl_extract/util/constructs.pyi
+++ b/smpl_extract/util/constructs.pyi
@@ -78,8 +78,9 @@ class ElementAdapter(Adapter):
         ...
 
 
+    @classmethod
     def wrap_child_realization(
-        self,
+        cls,
         f_realize: Callable[[], List[Element]],
         context: Dict[str, Any]
     ) -> Callable[[Dict[str, Any]], List[Element]]:


### PR DESCRIPTION
This PR fixes #1. It introduces the following behavior:
  1. Roland S-7xx images containing headers of the form:
       * ` SYS-772 HardDisk Sys Ver. 2.19`
       * ` SYS-772 HardDisk Sys Ver.2.13b`
       * ` SYS-772 HardDisk Sys Ver. 2.21`
       * ` SYS-772 HardDisk Sys Ver.32k-4`

     are now correctly identified as Roland S-7xx Images.

  2. Roland S-7xx images containing Orphan Performances 
     (Performances listed in the Performance Directory but without a parent Volume) 
     now place Orphan Performance in a Pseudo-Volume titled either `All Performances` 
     or `_Orphan_perf` depending on whether the image contains any Volumes whatsoever.

  3. This tool will sanitize file/directory names consisting entirely of spaces/periods/dashes
     by prepending/appending `0`s to the beginning/end of the file/directory name.
